### PR TITLE
 claude: use standard logging library slog

### DIFF
--- a/cmd/fractalexplorer/main.go
+++ b/cmd/fractalexplorer/main.go
@@ -1,9 +1,8 @@
 package main
 
 import (
+	"log/slog"
 	"os"
-
-	"github.com/op/go-logging"
 
 	"github.com/jameshiew/fractal-explorer/internal/gui"
 )
@@ -11,11 +10,13 @@ import (
 const title = "Fractal Explorer"
 
 func main() {
-	logging.SetBackend(logging.NewLogBackend(os.Stdout, "", 0))
-	logging.SetFormatter(logging.MustStringFormatter(`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`))
-	log := logging.MustGetLogger(title)
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}
+	handler := slog.NewTextHandler(os.Stdout, opts)
+	logger := slog.New(handler)
 
-	log.Info("Starting up")
-	gui.Run(log, title)
-	log.Info("Shutting down")
+	logger.Info("Starting up")
+	gui.Run(logger, title)
+	logger.Info("Shutting down")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.24.5
 
 require (
 	fyne.io/fyne/v2 v2.6.1
-	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/nicksnyder/go-i18n/v2 v2.6.0 h1:C/m2NNWNiTB6SK4Ao8df5EWm3JETSTIGNXBpM
 github.com/nicksnyder/go-i18n/v2 v2.6.0/go.mod h1:88sRqr0C6OPyJn0/KRNaEz1uWorjxIKP7rUUcvycecE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
-github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
 github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -9,7 +9,7 @@ import (
 )
 
 type logger interface {
-	Infof(string, ...interface{})
+	Info(msg string, args ...any)
 }
 
 type drawerInstrumenter struct {
@@ -21,7 +21,7 @@ func (i *drawerInstrumenter) instrument(nPixels int) (finish func()) {
 	start := time.Now()
 	return func() {
 		duration := time.Since(start)
-		i.log.Infof("%vpx in %v [%v px/s] (%v renders)", nPixels, duration, float64(nPixels)/float64(duration)*1_000_000_000, i.rendered)
+		i.log.Info("Render completed", "pixels", nPixels, "duration", duration, "pixels_per_second", float64(nPixels)/float64(duration)*1_000_000_000, "render_count", i.rendered)
 		i.rendered++
 	}
 }

--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -21,7 +21,8 @@ func (i *drawerInstrumenter) instrument(nPixels int) (finish func()) {
 	start := time.Now()
 	return func() {
 		duration := time.Since(start)
-		i.log.Info("Render completed", "pixels", nPixels, "duration", duration, "pixels_per_second", float64(nPixels)/float64(duration)*1_000_000_000, "render_count", i.rendered)
+		pixelsPerSecond := float64(nPixels) / duration.Seconds()
+		i.log.Info("Render completed", "pixels", nPixels, "duration", duration, "pixels_per_second", pixelsPerSecond, "render_count", i.rendered)
 		i.rendered++
 	}
 }

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -3,7 +3,7 @@ package gui
 import "fyne.io/fyne/v2/app"
 
 type logger interface {
-	Infof(string, ...interface{})
+	Info(msg string, args ...any)
 }
 
 // Run launches the GUI and blocks until exit

--- a/internal/gui/taps.go
+++ b/internal/gui/taps.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (f *fractalWidget) Tapped(event *fyne.PointEvent) {
-	f.log.Infof("Tapped at (%v, %v)", event.Position.X, event.Position.Y)
+	f.log.Info("Tapped", "x", event.Position.X, "y", event.Position.Y)
 	defer func() {
 		if f.renderer == nil {
 			return

--- a/internal/gui/widget.go
+++ b/internal/gui/widget.go
@@ -36,7 +36,7 @@ func (f *fractalWidget) Size() fyne.Size {
 
 func (f *fractalWidget) Resize(size fyne.Size) {
 	f.size = size
-	f.log.Infof("Resized to %v", size)
+	f.log.Info("Resized", "size", size)
 	if f.renderer == nil {
 		return
 	}


### PR DESCRIPTION
1. Replaced logging initialization in cmd/fractalexplorer/main.go:13-17 with slog setup
2. Updated logger interfaces in internal/gui/gui.go:5-7 and internal/draw/draw.go:11-13
3. Converted log statements to use structured logging with slog's key-value pairs
4. Removed the go-logging dependency from go.mod